### PR TITLE
Fix valid words in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ curl -s ... | grep -v [dukfiht] | grep .r... | grep n | grep -v ...n. | grep g |
 which'll return the following list of potentially valid words:
 
 ```
-grain
 groan
-groin
 green
-grein
 grown
 ```
 


### PR DESCRIPTION
The `i` wasn't taken into account in the wordlist