### PR TITLE
Remove word "spick" as not in wordle list

### DIFF
--- a/words
+++ b/words
@@ -4630,7 +4630,6 @@ fecht
 oxers
 junky
 lairy
-spick
 zibet
 typps
 dagos


### PR DESCRIPTION
Word "spick" is not available on wordle, so removing it.